### PR TITLE
fix javelin research cost

### DIFF
--- a/content/units/blAir/javelin.hjson
+++ b/content/units/blAir/javelin.hjson
@@ -158,4 +158,9 @@ weapons:[
 
 research: {
   parent: spear
+  requirements: [
+    silicon/83000
+    titanium/72000
+    plastanium/62000
+  ]
 }


### PR DESCRIPTION
Modded units dont have precalculated research costs. This adds default t4 research costs.